### PR TITLE
Preserve full error content when passing up

### DIFF
--- a/src/commands/data/testAuthentication.js
+++ b/src/commands/data/testAuthentication.js
@@ -29,12 +29,13 @@ export default function testAuthentication(pinataApiKey, pinataSecretApiKey) {
         }).catch(function (error) {
             if (error && error.response && error.response && error.response.data && error.response.data.error) {
                 reject({
-                    error: `${error.response.data.error}`
+                    error: error.response.data.error
+                });
+            } else {
+                reject({
+                    error: error
                 });
             }
-            reject({
-                error: `${error}`
-            });
         });
     });
 };

--- a/src/commands/data/userPinList/userPinList.js
+++ b/src/commands/data/userPinList/userPinList.js
@@ -29,12 +29,13 @@ export default function userPinList(pinataApiKey, pinataSecretApiKey, filters) {
             //  handle error here
             if (error && error.response && error.response && error.response.data && error.response.data.error) {
                 reject({
-                    error: `${error.response.data.error}`
+                    error: error.response.data.error
+                });
+            } else {
+                reject({
+                    error: error
                 });
             }
-            reject({
-                error: `${error}`
-            });
         });
     });
 }

--- a/src/commands/data/userPinnedDataTotal.js
+++ b/src/commands/data/userPinnedDataTotal.js
@@ -27,12 +27,13 @@ export default function userPinnedDataTotal(pinataApiKey, pinataSecretApiKey) {
             //  handle error here
             if (error && error.response && error.response && error.response.data && error.response.data.error) {
                 reject({
-                    error: `${error.response.data.error}`
+                    error: error.response.data.error
+                });
+            } else {
+                reject({
+                    error: error
                 });
             }
-            reject({
-                error: `${error}`
-            });
         });
     });
 }

--- a/src/commands/pinning/addHashToPinQueue.js
+++ b/src/commands/pinning/addHashToPinQueue.js
@@ -50,12 +50,13 @@ export default function addHashToPinQueue(pinataApiKey, pinataSecretApiKey, hash
             //  handle error here
             if (error && error.response && error.response && error.response.data && error.response.data.error) {
                 reject({
-                    error: `${error.response.data.error}`
+                    error: error.response.data.error
+                });
+            } else {
+                reject({
+                    error: error
                 });
             }
-            reject({
-                error: `${error}`
-            });
         });
     });
 }

--- a/src/commands/pinning/pinFileToIPFS.js
+++ b/src/commands/pinning/pinFileToIPFS.js
@@ -49,12 +49,13 @@ export default function pinFileToIPFS(pinataApiKey, pinataSecretApiKey, readStre
             //  handle error here
             if (error && error.response && error.response && error.response.data && error.response.data.error) {
                 reject({
-                    error: `${error.response.data.error}`
+                    error: error.response.data.error
+                });
+            } else {
+                reject({
+                    error: error
                 });
             }
-            reject({
-                error: `${error}`
-            });
         });
     });
 }

--- a/src/commands/pinning/pinHashToIPFS.js
+++ b/src/commands/pinning/pinHashToIPFS.js
@@ -47,15 +47,7 @@ export default function pinHashToIPFS(pinataApiKey, pinataSecretApiKey, hashToPi
             }
             resolve(result.data);
         }).catch(function (error) {
-            //  handle error here
-            if (error && error.response && error.response && error.response.data && error.response.data.error) {
-                reject({
-                    error: `${error.response.data.error}`
-                });
-            }
-            reject({
-                error: `${error}`
-            });
+            reject(error);
         });
     });
 }

--- a/src/commands/pinning/pinHashToIPFS.js
+++ b/src/commands/pinning/pinHashToIPFS.js
@@ -47,7 +47,16 @@ export default function pinHashToIPFS(pinataApiKey, pinataSecretApiKey, hashToPi
             }
             resolve(result.data);
         }).catch(function (error) {
-            reject(error);
+            //  handle error here
+            if (error && error.response && error.response && error.response.data && error.response.data.error) {
+                reject({
+                    error: error.response.data.error
+                });
+            } else {
+                reject({
+                    error: error
+                });
+            }
         });
     });
 }

--- a/src/commands/pinning/pinJSONToIPFS.js
+++ b/src/commands/pinning/pinJSONToIPFS.js
@@ -44,12 +44,13 @@ export default function pinJSONToIPFS(pinataApiKey, pinataSecretApiKey, body, op
             //  handle error here
             if (error && error.response && error.response && error.response.data && error.response.data.error) {
                 reject({
-                    error: `${error.response.data.error}`
+                    error: error.response.data.error
+                });
+            } else {
+                reject({
+                    error: error
                 });
             }
-            reject({
-                error: `${error}`
-            });
         });
     });
 }

--- a/src/commands/pinning/pinJobs/pinJobs.js
+++ b/src/commands/pinning/pinJobs/pinJobs.js
@@ -32,12 +32,13 @@ export default function pinJobs(pinataApiKey, pinataSecretApiKey, filters) {
             //  handle error here
             if (error && error.response && error.response && error.response.data && error.response.data.error) {
                 reject({
-                    error: `${error.response.data.error}`
+                    error: error.response.data.error
+                });
+            } else {
+                reject({
+                    error: error
                 });
             }
-            reject({
-                error: `${error}`
-            });
         });
     });
 }

--- a/src/commands/pinning/removePinFromIPFS.js
+++ b/src/commands/pinning/removePinFromIPFS.js
@@ -39,12 +39,13 @@ export default function removePinFromIPFS(pinataApiKey, pinataSecretApiKey, ipfs
             //  handle error here
             if (error && error.response && error.response && error.response.data && error.response.data.error) {
                 reject({
-                    error: `${error.response.data.error}`
+                    error: error.response.data.error
+                });
+            } else {
+                reject({
+                    error: error
                 });
             }
-            reject({
-                error: `${error}`
-            });
         });
     });
 }


### PR DESCRIPTION
It was returning `{ error: '[object Object]' }`, took me a while to
figure out that it wasn't a wrong serialization on my part, but that
it was already arriving as a string. Passing the whole error object
helped me figure out what the error was (http 400).