### PR TITLE
add maxContentLength parameter to axios request in pinFileToIPFS method

### DIFF
--- a/src/commands/pinning/pinFileToIPFS.js
+++ b/src/commands/pinning/pinFileToIPFS.js
@@ -35,6 +35,7 @@ export default function pinFileToIPFS(pinataApiKey, pinataSecretApiKey, readStre
             data,
             {
                 withCredentials: true,
+                maxContentLength: 'Infinity', //this is needed to prevent axios from erroring out with large files
                 headers: {
                     'Content-type': `multipart/form-data; boundary= ${data._boundary}`,
                     'pinata_api_key': pinataApiKey,


### PR DESCRIPTION
This is set properly in `pinFromFS`; however, it was not carried through to `pinFileToIPFS`.