### PR TITLE
Typescript support fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.12",
   "description": "Official SDK for the Pinata IPFS platform",
   "main": "lib/pinata-sdk.js",
-  "types": "dist/index.d.ts",
+  "types": "types/index.d.ts",
   "scripts": {
     "build": "webpack --env dev && webpack --env build && npm run test && tsc",
     "coverage": "jest --coverage",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "allowJs": true,
-    "outDir": "dist",
+    "outDir": "types",
     "target": "es5",
     "module": "commonjs",
     "lib": ["es2017", "es7", "es6", "dom"],

--- a/types/commands/data/pinList/pinList.d.ts
+++ b/types/commands/data/pinList/pinList.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Pin List
+ * @param {string} pinataApiKey
+ * @param {string} pinataSecretApiKey
+ * @param {string} filters
+ * @returns {Promise<unknown>}
+ */
+export default function pinList(pinataApiKey: string, pinataSecretApiKey: string, filters: string): Promise<unknown>;

--- a/types/commands/data/pinList/queryBuilder.d.ts
+++ b/types/commands/data/pinList/queryBuilder.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Query Builder
+ * @param {string} baseUrl
+ * @param {*} filters
+ * @returns {string}
+ */
+export default function queryBuilder(baseUrl: string, filters: any): string;

--- a/types/commands/data/testAuthentication.d.ts
+++ b/types/commands/data/testAuthentication.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Test Authentication
+ * @param {string} pinataApiKey
+ * @param {string} pinataSecretApiKey
+ * @returns {Promise<unknown>}
+ */
+export default function testAuthentication(pinataApiKey: string, pinataSecretApiKey: string): Promise<unknown>;

--- a/types/commands/data/userPinnedDataTotal.d.ts
+++ b/types/commands/data/userPinnedDataTotal.d.ts
@@ -1,0 +1,7 @@
+/**
+ * User Pinned Data Total
+ * @param {string} pinataApiKey
+ * @param {string} pinataSecretApiKey
+ * @returns {Promise<unknown>}
+ */
+export default function userPinnedDataTotal(pinataApiKey: string, pinataSecretApiKey: string): Promise<unknown>;

--- a/types/commands/pinning/hashMetadata.d.ts
+++ b/types/commands/pinning/hashMetadata.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Hash Meta Data
+ * @param {string} pinataApiKey
+ * @param {string} pinataSecretApiKey
+ * @param {*} ipfsPinHash
+ * @param {*} metadata
+ * @returns {Promise<unknown>}
+ */
+export default function hashMetadata(pinataApiKey: string, pinataSecretApiKey: string, ipfsPinHash: any, metadata: any): Promise<unknown>;

--- a/types/commands/pinning/hashPinPolicy.d.ts
+++ b/types/commands/pinning/hashPinPolicy.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Hash Pin Policy
+ * @param {string} pinataApiKey
+ * @param {string} pinataSecretApiKey
+ * @param {*} ipfsPinHash
+ * @param {*} newPinPolicy
+ * @returns {Promise<unknown>}
+ */
+export default function hashPinPolicy(pinataApiKey: string, pinataSecretApiKey: string, ipfsPinHash: any, newPinPolicy: any): Promise<unknown>;

--- a/types/commands/pinning/pinByHash.d.ts
+++ b/types/commands/pinning/pinByHash.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Pin By Hash
+ * @param {string} pinataApiKey
+ * @param {string} pinataSecretApiKey
+ * @param {*} hashToPin
+ * @param {*} options
+ * @returns {Promise<unknown>}
+ */
+export default function pinByHash(pinataApiKey: string, pinataSecretApiKey: string, hashToPin: any, options: any): Promise<unknown>;

--- a/types/commands/pinning/pinFileToIPFS.d.ts
+++ b/types/commands/pinning/pinFileToIPFS.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Pin File to IPFS
+ * @param {string} pinataApiKey
+ * @param {string} pinataSecretApiKey
+ * @param {*} readStream
+ * @param {*} options
+ * @returns {Promise<unknown>}
+ */
+export default function pinFileToIPFS(pinataApiKey: string, pinataSecretApiKey: string, readStream: any, options: any): Promise<unknown>;

--- a/types/commands/pinning/pinFromFS.d.ts
+++ b/types/commands/pinning/pinFromFS.d.ts
@@ -1,0 +1,9 @@
+/**
+ * PinFromFS
+ * @param {string} pinataApiKey
+ * @param {string} pinataSecretApiKey
+ * @param {string} sourcePath
+ * @param {*} options
+ * @returns {Promise<unknown>}
+ */
+export default function pinFromFS(pinataApiKey: string, pinataSecretApiKey: string, sourcePath: string, options: any): Promise<unknown>;

--- a/types/commands/pinning/pinJSONToIPFS.d.ts
+++ b/types/commands/pinning/pinJSONToIPFS.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Pin JSON to IPFS
+ * @param {string} pinataApiKey
+ * @param {string} pinataSecretApiKey
+ * @param {*} body
+ * @param {*} options
+ * @returns {Promise<unknown>}
+ */
+export default function pinJSONToIPFS(pinataApiKey: string, pinataSecretApiKey: string, body: any, options: any): Promise<unknown>;

--- a/types/commands/pinning/pinJobs/pinJobs.d.ts
+++ b/types/commands/pinning/pinJobs/pinJobs.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Pin Jobs
+ * @param {string} pinataApiKey
+ * @param {string} pinataSecretApiKey
+ * @param {*} filters
+ * @returns {Promise<unknown>}
+ */
+export default function pinJobs(pinataApiKey: string, pinataSecretApiKey: string, filters: any): Promise<unknown>;

--- a/types/commands/pinning/pinJobs/queryBuilder.d.ts
+++ b/types/commands/pinning/pinJobs/queryBuilder.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Query Buidler
+ * @param {string} baseUrl
+ * @param {*} filters
+ * @returns {*}
+ */
+export default function queryBuilder(baseUrl: string, filters: any): any;

--- a/types/commands/pinning/unpin.d.ts
+++ b/types/commands/pinning/unpin.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Unpin
+ * @param {string} pinataApiKey
+ * @param {string} pinataSecretApiKey
+ * @param {string} hashToUnpin
+ * @returns {Promise<unknown>}
+ */
+export default function unpin(pinataApiKey: string, pinataSecretApiKey: string, hashToUnpin: string): Promise<unknown>;

--- a/types/commands/pinning/userPinPolicy.d.ts
+++ b/types/commands/pinning/userPinPolicy.d.ts
@@ -1,0 +1,8 @@
+/**
+ * User Pin Policy
+ * @param {string} pinataApiKey
+ * @param {string} pinataSecretApiKey
+ * @param {*} newPinPolicy
+ * @returns {Promise<unknown>}
+ */
+export default function userPinPolicy(pinataApiKey: string, pinataSecretApiKey: string, newPinPolicy: any): Promise<unknown>;

--- a/types/constants.d.ts
+++ b/types/constants.d.ts
@@ -1,0 +1,1 @@
+export const baseUrl: "https://api.pinata.cloud";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,362 @@
+/**
+ * @typedef {Record<string, string | number | null>} PinataMetadata
+ */
+/**
+ * @typedef PinataMetadataFilter
+ * @property {string} [name]
+ * @property {Record<string, {value: string, op: string}>} keyvalues
+ */
+/**
+ * @typedef {{id: string, desiredReplicationCount: number}} PinataPinPolicyItem
+ */
+/**
+ * @typedef PinataPinByHashOptions
+ * @property {string[]} [hostNodes]
+ * @property {{regions: PinataPinPolicyItem[]}} [customPinPolicy]
+ */
+/**
+ * @typedef PinataPinByHashPinOptions
+ * @property {PinataMetadata} [pinataMetadata]
+ * @property {PinataPinByHashOptions} [pinataOptions]
+ */
+/**
+ * @typedef PinataOptions
+ * @property {0 | 1} [cidVersion]
+ * @property {boolean} [wrapWithDirectory]
+ * @property {{regions: PinataPinPolicyItem[]}} [customPinPolicy]
+ */
+/**
+ * @typedef PinataPinOptions
+ * @property {PinataMetadata} [pinataMetadata]
+ * @property {PinataOptions} [pinataOptions]
+ */
+/**
+ * @typedef PinataPinJobsFilterOptions
+ * @property {'ASC' | 'DESC'} sort
+ * @property {string} [status]
+ * @property {string} [ipfs_pin_hash]
+ * @property {number} [limit]
+ * @property {number} [offset]
+ */
+/**
+ * @typedef PinataPinListFilterOptions
+ * @property {string} [hashContains]
+ * @property {string} [pinStart]
+ * @property {string} [pinEnd]
+ * @property {string} [unpinStart]
+ * @property {string} [unpinEnd]
+ * @property {number} [pinSizeMin]
+ * @property {number} [pinSizeMax]
+ * @property {string} [status]
+ * @property {number} [pageLimit]
+ * @property {number} [pageOffset]
+ * @property {PinataMetadataFilter} [metadata]
+ */
+/**
+ * @typedef PinataPinByHashResponse
+ * @property {number | string} id
+ * @property {string} ipfsHash
+ * @property {string} status
+ * @property {string} name
+ */
+/**
+ * @typedef PinataPinResponse
+ * @property {string} IpfsHash
+ * @property {number} PinSize
+ * @property {string} Timestamp
+ */
+/**
+ * @typedef PinataPinJobsResponseRow
+ * @property {number | string} id
+ * @property {string} ipfs_pin_hash
+ * @property {string} date_queued
+ * @property {string | undefined | null} name
+ * @property {string} status
+ */
+/**
+ * @typedef PinataPinJobsResponse
+ * @property {number} count
+ * @property {PinataPinJobsResponseRow[]} rows
+ */
+/**
+ * @typedef PinataPinListResponseRow
+ * @property {number | string} id
+ * @property {string} ipfs_pin_hash
+ * @property {number} size
+ * @property {string | number} user_id
+ * @property {string} date_pinned
+ * @property {string} date_unpinned
+ * @property {PinataMetadata} metadata
+ */
+/**
+ * @typedef PinataPinListResponse
+ * @property {number} count
+ * @property {PinataPinListResponseRow[]} rows
+ */
+/**
+ * Hash meta data
+ * @callback hashMetadata
+ * @param {string} ipfsPinHash
+ * @param {PinataMetadata} metadata
+ * @returns {Promise<any>}
+ */
+/**
+ * Hash pin policy
+ * @callback hashPinPolicy
+ * @param {string} ipfsPinHash
+ * @param {{regions: PinataPinPolicyItem[]}} newPinPolicy
+ * @returns {Promise<any>}
+ */
+/**
+ * Pin by hash
+ * @callback pinByHash
+ * @param {string} hashToPin
+ * @param {PinataPinByHashPinOptions} [options]
+ * @returns {Promise<PinataPinByHashResponse>}
+ */
+/**
+ * Pin file to IPFS
+ * @callback pinFileToIPFS
+ * @param {ReadStream} readableStream
+ * @param {PinataPinOptions} [options]
+ * @returns {Promise<PinataPinResponse>}
+ */
+/**
+ * Pin from FS
+ * @callback pinFromFS
+ * @param {string} sourcePath
+ * @param {PinataPinOptions} [options]
+ * @returns {Promise<PinataPinResponse>}
+ */
+/**
+ * Pin Jobs
+ * @callback pinJobs
+ * @param {PinataPinJobsFilterOptions} [filters]
+ * @returns {Promise<PinataPinJobsResponse>}
+ */
+/**
+ * Pin JSON to IPFS
+ * @callback pinJSONToIPFS
+ * @param {Object} body
+ * @param {PinataPinOptions} [options]
+ * @returns {Promise<PinataPinResponse>}
+ */
+/**
+ * Unpin
+ * @callback unpin
+ * @param {string} hashToUnpin
+ * @returns {Promise<any>}
+ */
+/**
+ * User Pin Policy
+ * @callback userPinPolicy
+ * @param {{regions: PinataPinPolicyItem[]}} newPinPolicy
+ * @returns {Promise<any>}
+ */
+/**
+ * Test Authentication
+ * @callback testAuthentication
+ * @returns {Promise<{authenticated: boolean}>}
+ */
+/**
+ * Pin List
+ * @callback pinList
+ * @param {PinataPinListFilterOptions} [filters]
+ * @returns {Promise<PinataPinListResponse>}
+ */
+/**
+ * User Pinned Data Total
+ * @callback userPinnedDataTotal
+ * @returns {Promise<number>}
+ */
+/**
+ * @typedef PinataClient
+ * @property {pinByHash} pinByHash
+ * @property {hashMetadata} hashMetadata
+ * @property {hashPinPolicy} hashPinPolicy
+ * @property {pinFileToIPFS} pinFileToIPFS
+ * @property {pinFromFS} pinFromFS
+ * @property {pinJSONToIPFS} pinJSONToIPFS
+ * @property {pinJobs} pinJobs
+ * @property {unpin} unpin
+ * @property {userPinPolicy} userPinPolicy
+ * @property {testAuthentication} testAuthentication
+ * @property {pinList} pinList
+ * @property {userPinnedDataTotal} userPinnedDataTotal
+ */
+/**
+ * Pinata Client
+ *
+ * @param {string} pinataApiKey
+ * @param {string} pinataSecretApiKey
+ * @returns {PinataClient}
+ */
+export default function pinataClient(pinataApiKey: string, pinataSecretApiKey: string): PinataClient;
+export type PinataMetadata = Record<string, string | number | null>;
+export type PinataMetadataFilter = {
+    name?: string | undefined;
+    keyvalues: Record<string, {
+        value: string;
+        op: string;
+    }>;
+};
+export type PinataPinPolicyItem = {
+    id: string;
+    desiredReplicationCount: number;
+};
+export type PinataPinByHashOptions = {
+    hostNodes?: string[] | undefined;
+    customPinPolicy?: {
+        regions: PinataPinPolicyItem[];
+    } | undefined;
+};
+export type PinataPinByHashPinOptions = {
+    pinataMetadata?: PinataMetadata | undefined;
+    pinataOptions?: PinataPinByHashOptions | undefined;
+};
+export type PinataOptions = {
+    cidVersion?: 0 | 1 | undefined;
+    wrapWithDirectory?: boolean | undefined;
+    customPinPolicy?: {
+        regions: PinataPinPolicyItem[];
+    } | undefined;
+};
+export type PinataPinOptions = {
+    pinataMetadata?: PinataMetadata | undefined;
+    pinataOptions?: PinataOptions | undefined;
+};
+export type PinataPinJobsFilterOptions = {
+    sort: 'ASC' | 'DESC';
+    status?: string | undefined;
+    ipfs_pin_hash?: string | undefined;
+    limit?: number | undefined;
+    offset?: number | undefined;
+};
+export type PinataPinListFilterOptions = {
+    hashContains?: string | undefined;
+    pinStart?: string | undefined;
+    pinEnd?: string | undefined;
+    unpinStart?: string | undefined;
+    unpinEnd?: string | undefined;
+    pinSizeMin?: number | undefined;
+    pinSizeMax?: number | undefined;
+    status?: string | undefined;
+    pageLimit?: number | undefined;
+    pageOffset?: number | undefined;
+    metadata?: PinataMetadataFilter | undefined;
+};
+export type PinataPinByHashResponse = {
+    id: number | string;
+    ipfsHash: string;
+    status: string;
+    name: string;
+};
+export type PinataPinResponse = {
+    IpfsHash: string;
+    PinSize: number;
+    Timestamp: string;
+};
+export type PinataPinJobsResponseRow = {
+    id: number | string;
+    ipfs_pin_hash: string;
+    date_queued: string;
+    name: string | undefined | null;
+    status: string;
+};
+export type PinataPinJobsResponse = {
+    count: number;
+    rows: PinataPinJobsResponseRow[];
+};
+export type PinataPinListResponseRow = {
+    id: number | string;
+    ipfs_pin_hash: string;
+    size: number;
+    user_id: string | number;
+    date_pinned: string;
+    date_unpinned: string;
+    metadata: PinataMetadata;
+};
+export type PinataPinListResponse = {
+    count: number;
+    rows: PinataPinListResponseRow[];
+};
+/**
+ * Hash meta data
+ */
+export type hashMetadata = (ipfsPinHash: string, metadata: PinataMetadata) => Promise<any>;
+/**
+ * Hash pin policy
+ */
+export type hashPinPolicy = (ipfsPinHash: string, newPinPolicy: {
+    regions: PinataPinPolicyItem[];
+}) => Promise<any>;
+/**
+ * Pin by hash
+ */
+export type pinByHash = (hashToPin: string, options?: PinataPinByHashPinOptions | undefined) => Promise<PinataPinByHashResponse>;
+/**
+ * Pin file to IPFS
+ */
+export type pinFileToIPFS = (readableStream: any, options?: PinataPinOptions | undefined) => Promise<PinataPinResponse>;
+/**
+ * Pin from FS
+ */
+export type pinFromFS = (sourcePath: string, options?: PinataPinOptions | undefined) => Promise<PinataPinResponse>;
+/**
+ * Pin Jobs
+ */
+export type pinJobs = (filters?: PinataPinJobsFilterOptions | undefined) => Promise<PinataPinJobsResponse>;
+/**
+ * Pin JSON to IPFS
+ */
+export type pinJSONToIPFS = (body: Object, options?: PinataPinOptions | undefined) => Promise<PinataPinResponse>;
+/**
+ * Unpin
+ */
+export type unpin = (hashToUnpin: string) => Promise<any>;
+/**
+ * User Pin Policy
+ */
+export type userPinPolicy = (newPinPolicy: {
+    regions: PinataPinPolicyItem[];
+}) => Promise<any>;
+/**
+ * Test Authentication
+ */
+export type testAuthentication = () => Promise<{
+    authenticated: boolean;
+}>;
+/**
+ * Pin List
+ */
+export type pinList = (filters?: PinataPinListFilterOptions | undefined) => Promise<PinataPinListResponse>;
+/**
+ * User Pinned Data Total
+ */
+export type userPinnedDataTotal = () => Promise<number>;
+export type PinataClient = {
+    pinByHash: pinByHash;
+    hashMetadata: hashMetadata;
+    hashPinPolicy: hashPinPolicy;
+    pinFileToIPFS: pinFileToIPFS;
+    pinFromFS: pinFromFS;
+    pinJSONToIPFS: pinJSONToIPFS;
+    pinJobs: pinJobs;
+    unpin: unpin;
+    userPinPolicy: userPinPolicy;
+    testAuthentication: testAuthentication;
+    pinList: pinList;
+    userPinnedDataTotal: userPinnedDataTotal;
+};
+import pinByHash from "./commands/pinning/pinByHash";
+import hashMetadata from "./commands/pinning/hashMetadata";
+import hashPinPolicy from "./commands/pinning/hashPinPolicy";
+import pinFileToIPFS from "./commands/pinning/pinFileToIPFS";
+import pinFromFS from "./commands/pinning/pinFromFS";
+import pinJSONToIPFS from "./commands/pinning/pinJSONToIPFS";
+import pinJobs from "./commands/pinning/pinJobs/pinJobs";
+import unpin from "./commands/pinning/unpin";
+import userPinPolicy from "./commands/pinning/userPinPolicy";
+import testAuthentication from "./commands/data/testAuthentication";
+import pinList from "./commands/data/pinList/pinList";
+import userPinnedDataTotal from "./commands/data/userPinnedDataTotal";

--- a/types/util/validators.d.ts
+++ b/types/util/validators.d.ts
@@ -1,0 +1,26 @@
+/**
+ * Validate API Keys
+ * @param {string} pinataApiKey
+ * @param {string} pinataSecretApiKey
+ */
+export function validateApiKeys(pinataApiKey: string, pinataSecretApiKey: string): void;
+/**
+ * Validate host Nodes
+ * @param {*} hostNodes
+ */
+export function validateHostNodes(hostNodes: any): void;
+/**
+ * Validate MetaData
+ * @param {*} metadata
+ */
+export function validateMetadata(metadata: any): void;
+/**
+ * Validate Pin Policy Structure
+ * @param {*} pinPolicy
+ */
+export function validatePinPolicyStructure(pinPolicy: any): void;
+/**
+ * Validate Pinata Options
+ * @param {*} options
+ */
+export function validatePinataOptions(options: any): void;


### PR DESCRIPTION
@obo20 @polluterofminds 

Sorry, there has been some misunderstanding. I wrote under PR #58 that type definitions are currently being generated to the `dist` folder (which is, by default, gitignored), therefore, in order to achieve typescript support that folder needs to be added to the npm package. 

Currently, the dist folder is not a part of the npm package, therefore, the project does not work with TS.

I realize now that this info got lost somewhere and also that it's partly because it was not the best thing to do on my part to just throw this info out there but should've included a solution in the PR and that's what I did now.

I changed the folder into which type definitions are generated to `types`, and also added that folder to git. So, if the git repo is published to npm as is, then typescript support will be achieved. 

So, it is vital that the `types` folder is published to npm along with everything else.

Cheers!