### PR TITLE
Return reject within pinFromFS

### DIFF
--- a/src/commands/pinning/pinFromFS.js
+++ b/src/commands/pinning/pinFromFS.js
@@ -23,7 +23,7 @@ export default function pinFromFS(pinataApiKey, pinataSecretApiKey, sourcePath, 
 
         fs.stat(sourcePath, (err, stats) => {
             if (err) {
-                reject(err);
+                return reject(err);
             }
             if (stats.isFile()) {
                 //we need to create a single read stream instead of reading the directory recursively


### PR DESCRIPTION
In case of error the promise gets rejected but execution continues and fails with "Cannot read 'isFile' from undefined". This fixes it.