### PR TITLE
updated typedef for PinataMetadata

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import userPinnedDataTotal from './commands/data/userPinnedDataTotal';
 // OPTIONS
 
 /**
- * @typedef {Record<string, string | number | null>} PinataMetadata
+ * @typedef {{ name?: string, keyvalues?: Record<string, string | number | null> }} PinataMetadata
  */
 
 /**


### PR DESCRIPTION
A simple type fix to make the type definition more strict and allow for better use with typescript.

Resolves: https://github.com/PinataCloud/Pinata-SDK/issues/91

The type is based on the documentation stating what can be passed as metadata.

![Screenshot 2021-12-27 at 11 57 48](https://user-images.githubusercontent.com/18119833/147465254-4db5d10d-1674-4fd3-9a0c-75e9792d7f2b.png)
 