### PR TITLE
use Infinity numeric type correctly

### DIFF
--- a/src/commands/pinning/pinFileToIPFS.js
+++ b/src/commands/pinning/pinFileToIPFS.js
@@ -44,8 +44,8 @@ export default function pinFileToIPFS(pinataApiKey, pinataSecretApiKey, readStre
             data,
             {
                 withCredentials: true,
-                maxContentLength: 'Infinity', //this is needed to prevent axios from erroring out with large files
-                maxBodyLength: 'Infinity',
+                maxContentLength: Infinity, //this is needed to prevent axios from erroring out with large files
+                maxBodyLength: Infinity,
                 headers: {
                     'Content-type': `multipart/form-data; boundary= ${data._boundary}`,
                     'pinata_api_key': pinataApiKey,

--- a/src/commands/pinning/pinFromFS.js
+++ b/src/commands/pinning/pinFromFS.js
@@ -47,8 +47,8 @@ export default function pinFromFS(pinataApiKey, pinataSecretApiKey, sourcePath, 
                     data,
                     {
                         withCredentials: true,
-                        maxContentLength: 'Infinity', //this is needed to prevent axios from erroring out with large directories
-                        maxBodyLength: 'Infinity',
+                        maxContentLength: Infinity, //this is needed to prevent axios from erroring out with large directories
+                        maxBodyLength: Infinity,
                         headers: {
                             'Content-type': `multipart/form-data; boundary= ${data._boundary}`,
                             'pinata_api_key': pinataApiKey,
@@ -94,8 +94,8 @@ export default function pinFromFS(pinataApiKey, pinataSecretApiKey, sourcePath, 
                         data,
                         {
                             withCredentials: true,
-                            maxContentLength: 'Infinity',
-                            maxBodyLength: 'Infinity', //this is needed to prevent axios from erroring out with large directories
+                            maxContentLength: Infinity,
+                            maxBodyLength: Infinity, //this is needed to prevent axios from erroring out with large directories
                             headers: {
                                 'Content-type': `multipart/form-data; boundary= ${data._boundary}`,
                                 'pinata_api_key': pinataApiKey,


### PR DESCRIPTION
Instead of the string literal 'Infinity', use the numeric value Infinity