### PR TITLE
feat(pinFileToIpfs): support multiple readable streams, backward compatible

### DIFF
--- a/src/commands/pinning/pinFileToIPFS.js
+++ b/src/commands/pinning/pinFileToIPFS.js
@@ -25,7 +25,7 @@ export default function pinFileToIPFS(pinataApiKey, pinataSecretApiKey, readStre
         const endpoint = `${baseUrl}/pinning/pinFileToIPFS`;
 
         if (!(readStream instanceof stream.Readable || readStream instanceof NodeFormData)) {
-            reject(new Error('readStream is not a readable stream'));
+            reject(new Error('readStream is not a readable stream or form data'));
         }
 
         if (options) {

--- a/src/commands/pinning/pinFileToIPFS.js
+++ b/src/commands/pinning/pinFileToIPFS.js
@@ -24,7 +24,7 @@ export default function pinFileToIPFS(pinataApiKey, pinataSecretApiKey, readStre
 
         const endpoint = `${baseUrl}/pinning/pinFileToIPFS`;
 
-        if (!(readStream instanceof stream.Readable)) {
+        if (!(readStream instanceof stream.Readable || readStream instanceof NodeFormData)) {
             reject(new Error('readStream is not a readable stream'));
         }
 
@@ -41,7 +41,7 @@ export default function pinFileToIPFS(pinataApiKey, pinataSecretApiKey, readStre
 
         axios.post(
             endpoint,
-            data,
+            readStream instanceof NodeFormData ? readStream : data,
             {
                 withCredentials: true,
                 maxContentLength: 'Infinity', //this is needed to prevent axios from erroring out with large files

--- a/test/commands/pinning/pinFileToIPFS.test.js
+++ b/test/commands/pinning/pinFileToIPFS.test.js
@@ -1,20 +1,23 @@
 import axios from 'axios';
 import pinFileToIPFS from'../../../src/commands/pinning/pinFileToIPFS';
 import fs from 'fs';
+import NodeFormData from 'form-data';
 jest.mock('axios');
 
 //common values
 const nonStream = 'test';
 const validStream = fs.createReadStream('./pinata.png');
+const validFormData = new NodeFormData();
+validFormData.append('file', validStream, {filepath: 'test/filepath'});
 
 
-test('non-readableStream is passed in', () => {
-    expect(pinFileToIPFS('test', 'test', nonStream)).rejects.toEqual(Error('readStream is not a readable stream'));
+test('non-readableStream and non-formData is passed in', () => {
+    expect(pinFileToIPFS('test', 'test', nonStream)).rejects.toEqual(Error('readStream is not a readable stream or form data'));
 
     return undefined;
 });
 
-test('200 status is returned', () => {
+test('200 status is returned with valid stream', () => {
     const goodStatus = {
         status: 200,
         data: 'testData'
@@ -22,6 +25,16 @@ test('200 status is returned', () => {
     axios.post.mockResolvedValue(goodStatus);
     expect.assertions(1);
     expect(pinFileToIPFS('test', 'test', validStream)).resolves.toEqual(goodStatus.data);
+});
+
+test('200 status is returned with valid form data', () => {
+    const goodStatus = {
+        status: 200,
+        data: 'testData'
+    };
+    axios.post.mockResolvedValue(goodStatus);
+    expect.assertions(1);
+    expect(pinFileToIPFS('test', 'test', validFormData)).resolves.toEqual(goodStatus.data);
 });
 
 test('Result other than 200 status is returned', () => {


### PR DESCRIPTION
This PR is a backwards compatible change that enables pinning a directory as described in the docs. Without this change, one cannot take full advantage of the SDK and must use the API directly instead, which is undesired.