### PR TITLE
Fix: `PinataMetadata` type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,13 +12,21 @@ import userPinnedDataTotal from './commands/data/userPinnedDataTotal';
 // OPTIONS
 
 /**
- * @typedef {Record<string, string | number | null>} PinataMetadata
+ * @typedef {string | number | null} PinataMetadataValue
+ */
+
+/**
+ * @typedef {string | undefined} PinataMetadataName
+ */
+
+/**
+ * @typedef {{name?: PinataMetadataName, keyvalues?: Record<string, PinataMetadataValue>}} PinataMetadata
  */
 
 /**
  * @typedef PinataMetadataFilter
- * @property {string} [name]
- * @property {Record<string, {value: string, op: string}>} keyvalues
+ * @property {PinataMetadataName} [name]
+ * @property {Record<string, {value: PinataMetadataValue, op: string}>} keyvalues
  */
 
 /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,10 +1,16 @@
 /**
- * @typedef {Record<string, string | number | null>} PinataMetadata
+ * @typedef {string | number | null} PinataMetadataValue
+ */
+/**
+ * @typedef {string | undefined} PinataMetadataName
+ */
+/**
+ * @typedef {{name?: PinataMetadataName, keyvalues?: Record<string, PinataMetadataValue>}} PinataMetadata
  */
 /**
  * @typedef PinataMetadataFilter
- * @property {string} [name]
- * @property {Record<string, {value: string, op: string}>} keyvalues
+ * @property {PinataMetadataName} [name]
+ * @property {Record<string, {value: PinataMetadataValue, op: string}>} keyvalues
  */
 /**
  * @typedef {{id: string, desiredReplicationCount: number}} PinataPinPolicyItem
@@ -177,11 +183,11 @@
  * @returns {PinataClient}
  */
 export default function pinataClient(pinataApiKey: string, pinataSecretApiKey: string): PinataClient;
-type PinataMetadataValue = string | number | null;
-type PinataMetadataName = string | undefined;
+export type PinataMetadataValue = string | number | null;
+export type PinataMetadataName = string | undefined;
 export type PinataMetadata = {
     name?: PinataMetadataName;
-    keyvalue: Record<string, PinataMetadataValue>
+    keyvalues?: Record<string, PinataMetadataValue>;
 };
 export type PinataMetadataFilter = {
     name?: PinataMetadataName;
@@ -201,7 +207,7 @@ export type PinataPinByHashOptions = {
     } | undefined;
 };
 export type PinataPinByHashPinOptions = {
-    pinataMetadata?: Record<string, string | number | null> | undefined;
+    pinataMetadata?: PinataMetadata | undefined;
     pinataOptions?: PinataPinByHashOptions | undefined;
 };
 export type PinataOptions = {
@@ -212,7 +218,7 @@ export type PinataOptions = {
     } | undefined;
 };
 export type PinataPinOptions = {
-    pinataMetadata?: Record<string, string | number | null> | undefined;
+    pinataMetadata?: PinataMetadata | undefined;
     pinataOptions?: PinataOptions | undefined;
 };
 export type PinataPinJobsFilterOptions = {
@@ -281,7 +287,7 @@ export type pinByHash = (hashToPin: string, options?: PinataPinByHashPinOptions 
 /**
  * Pin file to IPFS
  */
-export type pinFileToIPFS = (readableStream: any, options?: PinataPinOptions | undefined) => Promise<PinataPinResponse>;
+export type pinFileToIPFS = (readableStream: ReadStream, options?: PinataPinOptions | undefined) => Promise<PinataPinResponse>;
 /**
  * Pin from FS
  */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -177,11 +177,16 @@
  * @returns {PinataClient}
  */
 export default function pinataClient(pinataApiKey: string, pinataSecretApiKey: string): PinataClient;
-export type PinataMetadata = Record<string, string | number | null>;
+type PinataMetadataValue = string | number | null;
+type PinataMetadataName = string | undefined;
+export type PinataMetadata = {
+    name?: PinataMetadataName;
+    keyvalue: Record<string, PinataMetadataValue>
+};
 export type PinataMetadataFilter = {
-    name?: string | undefined;
+    name?: PinataMetadataName;
     keyvalues: Record<string, {
-        value: string;
+        value: PinataMetadataValue;
         op: string;
     }>;
 };


### PR DESCRIPTION
Fixes #68
Fixes #76

## Description

According to [your docs](https://github.com/PinataCloud/Pinata-SDK#pinata-metadata), metadata has a shape as follows:

> The metadata object can consist of the following values:
> 
> - name (optional) - A custom string to use as the name for your content
> - keyvalues (optional) - An object containing up to 10 custom key / value pairs. The values can be:
> - - strings
> - - numbers (integers or decimals)
> - - dates (provided in ISO_8601 format)

However, its corresponding type is not reflecting this, causing  compilation problems when using with Typescript.