### PR TITLE
fix getFilesByCount: does not honor filter 'pageOffset' and 'pageLimit' if passed

### DIFF
--- a/src/commands/data/getFilesByCount/getFilesByCount.ts
+++ b/src/commands/data/getFilesByCount/getFilesByCount.ts
@@ -14,8 +14,8 @@ export default function getFilesByCount(
     const asyncIterable = {
         [Symbol.asyncIterator]: () => {
             let i = 0;
-            const pageLimit = 10;
-            let pageOffset = 0;
+            const pageLimit = filters.pageLimit ?? 10;
+            let pageOffset = filters.pageOffset ?? 0;
             let cache: PinataPin[] = [];
             let keepLooping = false;
 


### PR DESCRIPTION
Currently,  `pageOffset` and `pageLimit` from the passed `filter` object are ignored. This is detrimental to api rate limits